### PR TITLE
Allow changing the command used to start clangd

### DIFF
--- a/LSP-clangd.sublime-settings
+++ b/LSP-clangd.sublime-settings
@@ -20,7 +20,7 @@
     "auto_complete_selector": "punctuation.accessor | (meta.preprocessor.include string - punctuation.definition.string.end)",
     "initializationOptions": {
         // A custom command to start clangd. Set `binary` to `custom` to use this command.
-        // The configuration arguments are added to this command.
+        // The command-line arguments which are generated from the `clang.*` settings are appended to this command.
         // This can be used for MSYS2's clangd for example.
         "custom_command": [],
 

--- a/LSP-clangd.sublime-settings
+++ b/LSP-clangd.sublime-settings
@@ -4,17 +4,26 @@
     /////////////////////////
 
     // The clangd binary to use.
-    // "system": Prefers the system binary found in path
+    // "system": Prefers the system binary below
     // "auto": Prefers the system binary but falls back to GitHub without user intervention
     // "github": Prefers the latest tested release from GitHub
+    // "custom": Use the custom command in the initializationOptions below
     "binary": "system",
-    // The command to start `clangd`, generated internally.
+    // The binary to use when `binary` is set to `system`.
+    "system_binary": "clangd",
+    // Generated internally because clangd is configured via command line arguments.
+    // DO NOT CHANGE THIS, use `system_binary` or `custom_command` instead.
     "command": [],
     // Enable clangd for C/C++ and Objective-C/C++
     "selector": "source.c | source.c++ | source.objc | source.objc++ | source.cuda-c++",
     // Makes the auto-complete not trigger twice when writing a -> or when writing ::
     "auto_complete_selector": "punctuation.accessor | (meta.preprocessor.include string - punctuation.definition.string.end)",
     "initializationOptions": {
+        // A custom command to start clangd. Set `binary` to `custom` to use this command.
+        // The configuration arguments are added to this command.
+        // This can be used for MSYS2's clangd for example.
+        "custom_command": [],
+
         // @see https://clangd.llvm.org/extensions#file-status
         // Enables receiving textDocument/clangd.fileStatus notifications.
         // -- unsupported --

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -38,7 +38,7 @@
                     "custom_command": {
                       "type": "array",
                       "default": [],
-                      "markdownDescription": "A custom command to start clangd. Set `binary` to `custom` to use this command. The configuration arguments are added to this command."
+                      "markdownDescription": "A custom command to start clangd. Set `binary` to `custom` to use this command. The command-line arguments which are generated from the `clang.*` settings are appended to this command."
                     },
                     "clangdFileStatus": {
                       "type": "boolean",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -17,17 +17,29 @@
                   "enum": [
                     "system",
                     "auto",
-                    "github"
+                    "github",
+                    "custom"
                   ],
                   "enumDescriptions": [
                     "Prefers the system binary found in path",
                     "Prefers the system binary but falls back to GitHub without user intervention",
                     "Prefers the latest tested release from GitHub",
+                    "Use the custom command in the initializationOptions below",
                   ],
+                },
+                "system_binary": {
+                  "type": "string",
+                  "default": "clangd",
+                  "markdownDescription": "The binary to use when `binary` is set to `system`."
                 },
                 "initializationOptions": {
                   "additionalProperties": false,
                   "properties": {
+                    "custom_command": {
+                      "type": "array",
+                      "default": [],
+                      "markdownDescription": "A custom command to start clangd. Set `binary` to `custom` to use this command. The configuration arguments are added to this command."
+                    },
                     "clangdFileStatus": {
                       "type": "boolean",
                       "description": "Enables receiving textDocument/clangd.fileStatus notifications.",
@@ -195,7 +207,9 @@
                       "default": null,
                       "description": "Sets the PCH storage. Storing PCHs in memory increases memory usages, but may improve performance",
                       "enum": [
-                        null, "disk", "memory"
+                        null,
+                        "disk",
+                        "memory"
                       ]
                     },
                     "clangd.enable-config": {
@@ -209,7 +223,12 @@
                       ],
                       "default": null,
                       "description": "Sets the clangd log level",
-                      "enum": [null, "error", "info", "verbose"]
+                      "enum": [
+                        null,
+                        "error",
+                        "info",
+                        "verbose"
+                      ]
                     },
                     "clangd.path-mappings": {
                       "type": [


### PR DESCRIPTION
Closes #10 

@takase1121 This PR introduces a new option for `"binary": "custom"`. Then the command can be set as:
```jsonc
"initializationOptions": {
        "custom_command": ["C:/msys64/msys2_shell.cmd", "-defterm", "-here", "-no-start", "-mingw64", "-c", "clangd"],
}
```
Please report back if that fixes the issue for you.

@kutu initializationOptions can be overwritten per project.
@berteauxjb The system binary can now be set as: `"system_binary": "clangd-12"`