### PR TITLE
feat: enable editsNearCursor experimental capability

### DIFF
--- a/LSP-clangd.sublime-settings
+++ b/LSP-clangd.sublime-settings
@@ -102,4 +102,11 @@
         // Pretty-print JSON output
         "clangd.pretty": null,
     },
+    "experimental_capabilities": {
+        "textDocument": {
+            "completion": {
+                "editsNearCursor": true
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is a feature that allows clangd to auto-change `.` to `->` on selecting completion.

For example in a document like this after `pTest.|`:

```cpp
typedef struct {
    int    a;
    short  b;
    char   c;
}TEST_STRUCT;

int main()
{
    TEST_STRUCT   test1;
    TEST_STRUCT * pTest = &test1;
    pTest.;
    return 0;
}
```

This is also mentioned in https://github.com/sublimelsp/LSP/issues/2521