### PR TITLE
refactor: migrate to LspPlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 **/__pycache__

--- a/LSP-clangd.sublime-settings
+++ b/LSP-clangd.sublime-settings
@@ -11,9 +11,6 @@
     "binary": "system",
     // The binary to use when `binary` is set to `system`.
     "system_binary": "clangd",
-    // Generated internally because clangd is configured via command line arguments.
-    // DO NOT CHANGE THIS, use `system_binary` or `custom_command` instead.
-    "command": [],
     // Enable clangd for C/C++ and Objective-C/C++
     "selector": "source.c | source.c++ | source.objc | source.objc++ | source.cuda-c++",
     // Makes the auto-complete not trigger twice when writing a -> or when writing ::
@@ -108,5 +105,8 @@
                 "editsNearCursor": true
             }
         }
-    }
+    },
+    // Generated internally because clangd is configured via command line arguments.
+    // DO NOT CHANGE THIS, use `system_binary` or `custom_command` instead.
+    "command": [],
 }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Here are some ways to configure the package and the language server.
   {
      "settings": {
         "LSP": {
-           "clangd": {
+           "LSP-clangd": {
               "initialization_options": {
                 // Put your settings here eg.
                 // "clangd.header-insertion": "iwyu",

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,4 @@
 {
-    "install": "messages/install.txt"
+    "install": "messages/install.txt",
+    "2.0.0": "messages/2.0.0.txt"
 }

--- a/messages/2.0.0.txt
+++ b/messages/2.0.0.txt
@@ -1,0 +1,33 @@
+!!WARNING!!
+
+The key used to override LSP-clang settings in project settings has changed from "clang" to "LSP-clang".
+
+If you are using project-specific overrides for LSP-clang then you have to change the key for it to apply.
+
+Before:
+
+```
+{
+    "settings": {
+        "LSP": {
+            "clangd": {
+              // ...
+            }
+        }
+    }
+}
+```
+
+After:
+
+```
+{
+    "settings": {
+        "LSP": {
+            "LSP-clangd": {
+              // ...
+            }
+        }
+    }
+}
+```

--- a/messages/2.0.0.txt
+++ b/messages/2.0.0.txt
@@ -1,6 +1,6 @@
 !!WARNING!!
 
-The key used to override LSP-clang settings in project settings has changed from "clang" to "LSP-clang".
+The key used to override LSP-clangd settings in project settings has changed from "clangd" to "LSP-clangd".
 
 If you are using project-specific overrides for LSP-clang then you have to change the key for it to apply.
 

--- a/plugin.py
+++ b/plugin.py
@@ -7,20 +7,21 @@ import stat
 import sys
 import tempfile
 import zipfile
-from typing import Any, cast, final
+from os import PathLike
+from pathlib import Path
+from typing import cast, final
 from urllib.request import urlopen
 
 import sublime
 from LSP.plugin import (
-    AbstractPlugin,
     ClientConfig,
+    LspPlugin,
     LspTextCommand,
+    OnPreStartContext,
+    PluginStartError,
     Request,
-    Response,
-    WorkspaceFolder,
+    ServerResponse,
     parse_uri,
-    register_plugin,
-    unregister_plugin,
 )
 from LSP.plugin.core.protocol import ResponseError
 from LSP.plugin.core.views import text_document_identifier
@@ -34,15 +35,9 @@ for m in list(sys.modules.keys()):
 
 from .modules.version import CLANGD_VERSION  # noqa: E402
 
-SESSION_NAME = "clangd"
-STORAGE_DIR = "LSP-clangd"
 SETTINGS_FILENAME = "LSP-clangd.sublime-settings"
 GITHUB_DL_URL = 'https://github.com/clangd/clangd/releases/download/'\
                 + '{release_tag}/clangd-{platform}-{release_tag}.zip'
-# Options under `initialization_options` that are prefixed with this prefix
-# aren't really `initialization_options` but get converted to command line arguments
-# when this plugin starts the server.
-CLANGD_SETTING_PREFIX = "clangd."
 CLANGD_SETTING_TO_ARGUMENT = {
     "number-workers": "-j"
 }
@@ -56,11 +51,9 @@ def get_argument_for_setting(key: str) -> str:
     return CLANGD_SETTING_TO_ARGUMENT.get(key, "--" + key)
 
 
-def get_settings() -> sublime.Settings:
-    return sublime.load_settings(SETTINGS_FILENAME)
-
-
-def save_settings() -> None:
+def set_setting_and_save(key: str, value: str) -> None:
+    settings = sublime.load_settings(SETTINGS_FILENAME)
+    settings.set(key, value)
     return sublime.save_settings(SETTINGS_FILENAME)
 
 
@@ -76,14 +69,12 @@ def download_file(url: str, file: str) -> None:
         shutil.copyfileobj(response, out_file)
 
 
-def download_server(path: str):
+def download_server(path: str | PathLike[str]):
     with tempfile.TemporaryDirectory() as tempdir:
         zip_path = os.path.join(tempdir, "server.zip")
 
-        sublime.status_message(f"{SESSION_NAME}: Downloading server...")
         download_file(clangd_download_url(), zip_path)
 
-        sublime.status_message(f"{SESSION_NAME}: Extracting server...")
         with zipfile.ZipFile(zip_path, "r") as zip_file:
             zip_file.extractall(tempdir)
 
@@ -91,76 +82,57 @@ def download_server(path: str):
 
 
 @final
-class Clangd(AbstractPlugin):
+class Clangd(LspPlugin):
 
     @classmethod
     @override
-    def name(cls) -> str:
-        return SESSION_NAME
-
-    @classmethod
-    def storage_subpath(cls) -> str:
-        return os.path.join(cls.storage_path(), STORAGE_DIR)
-
-    @classmethod
-    def managed_clangd_path(cls) -> str | None:
-        binary_name = "clangd.exe" if sublime.platform() == "windows" else "clangd"
-        path = os.path.join(cls.storage_subpath(), "clangd_{version}/bin/{binary_name}".format(version=VERSION_STRING, binary_name=binary_name))
-        if os.path.exists(path):
-            return path
-        return None
-
-    @classmethod
-    def system_clangd_path(cls) -> str | None:
-        system_binary = cast('str', get_settings().get("system_binary"))
-        # Detect if clangd is installed or the command points to a valid binary.
-        # Fallback, shutil.which has issues on Windows.
-        system_binary_path = shutil.which(system_binary) or system_binary
-        if not os.path.isfile(system_binary_path):
-            return None
-        return system_binary_path
-
-    @classmethod
-    def clangd_path(cls) -> str | None:
-        """The command to start clangd without any configuration arguments"""
-        binary_setting = get_settings().get("binary")
-        if binary_setting == "system":
-            return cls.system_clangd_path()
-        elif binary_setting == "github":
-            return cls.managed_clangd_path()
+    def on_pre_start_async(cls, context: OnPreStartContext) -> None:
+        config = context.configuration
+        if config.root_settings.get("binary") == "custom":
+            clangd_base_command = cast('list[str]', config.initialization_options.get("custom_command"))
         else:
-            # binary_setting == "auto":
-            return cls.system_clangd_path() or cls.managed_clangd_path()
+            clangd_path = cls.clangd_path(config)
+            if clangd_path is None:
+                cls.install_clangd(config)
+            clangd_path = cls.clangd_path(config)
+            if clangd_path is None:
+                raise PluginStartError("clangd is currently not installed")
+            clangd_base_command = [str(clangd_path)]
+
+        config.command = clangd_base_command
+
+        for key, value in config.initialization_options.get("clangd").items():
+            if value is None:
+                continue  # Use clangd default
+
+            if isinstance(value, bool):
+                value = str(value).lower()
+
+            if isinstance(value, str) or isinstance(value, int):
+                config.command.append("{key}={value}".format(key=get_argument_for_setting(key), value=value))
+            else:
+                raise TypeError(f"[LSP-clangd] Type {type(value)} not supported for setting {key}.")
 
     @classmethod
-    @override
-    def needs_update_or_installation(cls) -> bool:
-        if get_settings().get("binary") == "custom":
-            return False
-        return cls.clangd_path() is None
-
-    @classmethod
-    @override
-    def install_or_update(cls) -> None:
+    def install_clangd(cls, configuration: ClientConfig) -> None:
         # Binary cannot be set to custom because needs_update_or_installation
         # returns False in this case
-        if get_settings().get("binary") == "system":
-            ans = sublime.yes_no_cancel_dialog("clangd was not found in your path. Would you like to auto-install clangd from GitHub?")
+        if configuration.root_settings.get("binary") == "system":
+            ans = sublime.ok_cancel_dialog (
+                "clangd was not found in your path. Would you like to auto-install clangd from GitHub?",
+                ok_title="Install")
             if ans == sublime.DIALOG_YES:
-                get_settings().set("binary", "auto")
-                save_settings()
+                set_setting_and_save("binary", "auto")
             else:  # sublime.DIALOG_NO or sublime.DIALOG_CANCEL
-                # dont raise explicitly here
-                # server start fails in on_pre_start
-                return
+                raise PluginStartError("clangd is currently not installed")
 
         # At this point clangd is not installed and
         # binary setting is "github" or "auto" -> perform installation
 
-        if os.path.isdir(cls.storage_subpath()):
-            shutil.rmtree(cls.storage_subpath())
-        os.makedirs(cls.storage_subpath())
-        download_server(cls.storage_subpath())
+        if cls.plugin_storage_path.is_dir():
+            shutil.rmtree(cls.plugin_storage_path)
+        cls.plugin_storage_path.mkdir(parents=True)
+        download_server(cls.plugin_storage_path)
 
         # zip does not preserve file mode
         path = cls.managed_clangd_path()
@@ -171,43 +143,33 @@ class Clangd(AbstractPlugin):
         os.chmod(path, st.st_mode | stat.S_IEXEC)
 
     @classmethod
-    @override
-    def on_pre_start(
-        cls,
-        window: sublime.Window,
-        initiating_view: sublime.View,
-        workspace_folders: list[WorkspaceFolder],
-        configuration: ClientConfig,
-    ) -> str | None:
+    def clangd_path(cls, configuration: ClientConfig) -> Path | None:
+        """The command to start clangd without any configuration arguments"""
+        binary_setting = configuration.root_settings.get("binary")
+        if binary_setting == "system":
+            return cls.system_clangd_path(configuration)
+        if binary_setting == "github":
+            return cls.managed_clangd_path()
+        # binary_setting == "auto":
+        return cls.system_clangd_path(configuration) or cls.managed_clangd_path()
 
-        if get_settings().get("binary") == "custom":
-            clangd_base_command = cast('list[str]', configuration.initialization_options.get("custom_command"))
-        else:
-            clangd_path = cls.clangd_path()
-            if not clangd_path:
-                raise ValueError("clangd is currently not installed.")
-            clangd_base_command = [clangd_path]
+    @classmethod
+    def system_clangd_path(cls, configuration: ClientConfig) -> Path | None:
+        system_binary = cast('str', configuration.root_settings.get("system_binary"))
+        # Detect if clangd is installed or the command points to a valid binary.
+        # Fallback, shutil.which has issues on Windows.
+        system_binary_path = Path(shutil.which(system_binary) or system_binary)
+        return system_binary_path if system_binary_path.is_file() else None
 
-        # The configuration is persisted
-        # reset the command to prevent adding an argument multiple times
-        configuration.command = clangd_base_command.copy()
+    @classmethod
+    def managed_clangd_path(cls) -> Path | None:
+        binary_name = "clangd.exe" if sublime.platform() == "windows" else "clangd"
+        path = cls.plugin_storage_path / f"clangd_{VERSION_STRING}" / "bin" / binary_name
+        return path if path.exists() else None
 
-        for key, value in configuration.initialization_options.get("clangd").items():
-            if value is None:
-                continue  # Use clangd default
-
-            if isinstance(value, bool):
-                value = str(value).lower()
-
-            if isinstance(value, str) or isinstance(value, int):
-                configuration.command.append("{key}={value}".format(key=get_argument_for_setting(key), value=value))
-            else:
-                raise TypeError(f"Type {type(value)} not supported for setting {key}.")
-        return None
-
-    def on_server_response_async(self, method: str, response: Response[Any]) -> None:
-        if method == "textDocument/hover" and isinstance(response.result, dict):
-            contents = response.result.get("contents")
+    def on_server_response_async(self, response: ServerResponse) -> None:
+        if response['method'] == "textDocument/hover" and isinstance(response['result'], dict):
+            contents = response['result'].get("contents")
             if isinstance(contents, dict) and contents.get("kind") == "markdown":
                 content = re.sub("[ ]{2,}\n-", "\n\n-", contents["value"])
                 contents["value"] = content
@@ -216,35 +178,29 @@ class Clangd(AbstractPlugin):
 @final
 class LspClangdSwitchSourceHeader(LspTextCommand):
 
-    session_name = SESSION_NAME
-
     @override
     def run(self, edit: sublime.Edit) -> None:
-        session = self.session_by_name(SESSION_NAME)
-        if not session:
-            return
-        request: Request[TextDocumentIdentifier, str] = Request("textDocument/switchSourceHeader",
-                                                                text_document_identifier(self.view))
-        session.send_request(request, self.on_response_async, self.on_error_async)
+        if session := self.session_by_name(self.session_name):
+            request: Request[TextDocumentIdentifier, str] = Request("textDocument/switchSourceHeader",
+                                                                    text_document_identifier(self.view))
+            session.send_request(request, self.on_response_async, self.on_error_async)
 
     def on_response_async(self, response: str):
         if not response:
-            sublime.status_message("{}: could not determine source/header".format(self.session_name))
+            sublime.status_message(f"{self.session_name}: could not determine source/header")
             return
         # session.open_uri_async(response) does currently not focus the view
         _, file_path = parse_uri(response)
-        window = self.view.window()
-        if not window:
-            return
-        window.open_file(file_path)
+        if window := self.view.window():
+            window.open_file(file_path)
 
     def on_error_async(self, error: ResponseError):
-        sublime.status_message("{}: could not switch to source/header: {}".format(self.session_name, error))
+        sublime.status_message(f"{self.session_name}: could not switch to source/header: {error}")
 
 
 def plugin_loaded() -> None:
-    register_plugin(Clangd)
+    Clangd.register()
 
 
 def plugin_unloaded() -> None:
-    unregister_plugin(Clangd)
+    Clangd.unregister()


### PR DESCRIPTION
Migrates to [LspPlugin](https://lsp.sublimetext.io/migrating_to_lsp_plugin).

Notable breaking change:
The session name changed from `clangd` to `LSP-clangd` as that's a requirement that session name matches package name with `LspPlugin`. That means it's a breaking change for people who have customized package settings in project settings.
